### PR TITLE
急了，不填都别开了

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -54,9 +54,9 @@ else:
     exit(1)
 
 # 检测Key是否存在
-if not os.getenv("DEEP_SEEK_KEY") and not os.getenv("SILICONFLOW_KEY") and not os.getenv("CHAT_ANY_WHERE_KEY"):
+if not os.getenv("SILICONFLOW_KEY"):
     logger.error("缺失必要的API KEY")
-    logger.info(f"请至少在.env.{os.getenv('ENVIRONMENT')}文件中填写SILICONFLOW_KEY后重新启动")
+    logger.error(f"请至少在.env.{os.getenv('ENVIRONMENT')}文件中填写SILICONFLOW_KEY后重新启动")
     exit(1)
 
 # 获取所有环境变量


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

移除了对 DEEP_SEEK_KEY 和 CHAT_ANY_WHERE_KEY 环境变量的强制要求，现在只需要 SILICONFLOW_KEY 即可。此外，将缺少 API 密钥的日志级别从 info 更改为 error。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Removes the requirement for DEEP_SEEK_KEY and CHAT_ANY_WHERE_KEY environment variables, now only SILICONFLOW_KEY is required. Also, changes the log level for missing API key from info to error.

</details>