### PR TITLE
feat: 增加 NixOS 开发环境配置（仅限开发）

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,6 @@ jieba.cache
 
 # vscode
 /.vscode
+
+# direnv
+/.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1741196730,
+        "narHash": "sha256-0Sj6ZKjCpQMfWnN0NURqRCQn2ob7YtXTAOTwCuz7fkA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "48913d8f9127ea6530a2a2f1bd4daa1b8685d8a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,50 +1,59 @@
 {
   description = "MaiMBot Nix Dev Env";
+  # 本配置仅方便用于开发，但是因为 nb-cli 上游打包中并未包含 nonebot2，因此目前本配置并不能用于运行和调试
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         pkgs = import nixpkgs {
           inherit system;
         };
 
-        # 读取 requirements.txt 文件
-        requirementsFile = builtins.readFile ./requirements.txt;
-
-        # 解析 requirements.txt 文件，提取包名
-        parseRequirements = content:
-          let
-            lines = builtins.split "\n" content;
-            # 过滤掉空行和注释
-            filteredLines = builtins.filter (line:
-              line != "" && !(builtins.match "^ *#.*" line)
-            ) lines;
-            # 提取包名（去掉版本号）
-            packageNames = builtins.map (line:
-              builtins.head (builtins.split "[=<>]" line)
-            ) filteredLines;
-          in
-          packageNames;
-
-        # 获取 requirements.txt 中的包名列表
-        requirements = parseRequirements requirementsFile;
-
-        # 动态生成 Python 环境
-        pythonEnv = pkgs.python3.withPackages (ps:
-          builtins.map (pkg: ps.${pkg}) requirements
+        pythonEnv = pkgs.python3.withPackages (
+          ps: with ps; [
+            pymongo
+            python-dotenv
+            pydantic
+            jieba
+            openai
+            aiohttp
+            requests
+            urllib3
+            numpy
+            pandas
+            matplotlib
+            networkx
+            python-dateutil
+            APScheduler
+            loguru
+            tomli
+            customtkinter
+            colorama
+            pypinyin
+            pillow
+            setuptools
+          ]
         );
       in
       {
         devShell = pkgs.mkShell {
-          buildInputs = [ pythonEnv ];
+          buildInputs = [
+            pythonEnv
+            pkgs.nb-cli
+          ];
 
           shellHook = ''
-            echo "Python environment is ready!"
           '';
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,52 @@
+{
+  description = "MaiMBot Nix Dev Env";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+
+        # 读取 requirements.txt 文件
+        requirementsFile = builtins.readFile ./requirements.txt;
+
+        # 解析 requirements.txt 文件，提取包名
+        parseRequirements = content:
+          let
+            lines = builtins.split "\n" content;
+            # 过滤掉空行和注释
+            filteredLines = builtins.filter (line:
+              line != "" && !(builtins.match "^ *#.*" line)
+            ) lines;
+            # 提取包名（去掉版本号）
+            packageNames = builtins.map (line:
+              builtins.head (builtins.split "[=<>]" line)
+            ) filteredLines;
+          in
+          packageNames;
+
+        # 获取 requirements.txt 中的包名列表
+        requirements = parseRequirements requirementsFile;
+
+        # 动态生成 Python 环境
+        pythonEnv = pkgs.python3.withPackages (ps:
+          builtins.map (pkg: ps.${pkg}) requirements
+        );
+      in
+      {
+        devShell = pkgs.mkShell {
+          buildInputs = [ pythonEnv ];
+
+          shellHook = ''
+            echo "Python environment is ready!"
+          '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
```
services:
  napcat:
    container_name: napcat
    environment:
      - tz=Asia/Shanghai
      - NAPCAT_UID=${NAPCAT_UID}
      - NAPCAT_GID=${NAPCAT_GID}
    ports:
      - 3000:3000
      - 3001:3001
      - 6099:6099
    restart: always
    volumes:
      - napcatQQ:/app/.config/QQ
      - napcatCONFIG:/app/napcat/config
      - maimbotDATA:/MaiMBot/data #麦麦的图片等要给napcat不然发送图片会有问题
    image: mlikiowa/napcat-docker:latest

  mongodb:
    container_name: mongodb
    environment:
      - tz=Asia/Shanghai
    expose:
      - "27017"
    restart: always
    volumes:
      - mongodb:/data/db
      - mongodbCONFIG:/data/configdb
    image: mongo:latest

  maimbot:
    container_name: maimbot
    environment:
      - tz=Asia/Shanghai
    expose:
      - "8080"
    restart: always
    depends_on:
      - mongodb
      - napcat
    volumes:
      - ./bot_config.toml:/MaiMBot/config/bot_config.toml
      - maimbotDATA:/MaiMBot/data
      - ./env.prod:/MaiMBot/.env.prod
    # image: sengokucola/maimbot:latest
    build: /home/rikki/WorkSpace/Dev/MaiMBot

volumes:
  maimbotCONFIG:
  maimbotDATA:
  napcatQQ:
  napcatCONFIG:
  mongodb:
  mongodbCONFIG:
```
可以  `build: /home/rikki/WorkSpace/Dev/MaiMBot` 手动指定打包位置来dev
记得每次测试前要先删除之前打包的镜像

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

为项目添加 NixOS 开发环境配置，包括一个 flake.nix 文件，用于定义包含 Python 包和 nb-cli 的开发环境。

杂项：
- 添加 .envrc 文件以与 direnv 一起使用。
- 添加 .gitignore 文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adds a NixOS development environment configuration for the project, including a flake.nix file that defines the development environment with Python packages and nb-cli.

Chores:
- Adds .envrc file to use with direnv.
- Adds .gitignore file.

</details>