### PR TITLE
feat: 1.将 napcatCONFIG 卷引入 maimbot，方便自动增加反向ws客户端；2.增加 docker 部署说明

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - napcatQQ:/app/.config/QQ
       - napcatCONFIG:/app/napcat/config
-      - maimbotDATA:/MaiMBot/data #麦麦的图片等要给napcat不然发送图片会有问题
+      - maimbotDATA:/MaiMBot/data # 麦麦的图片等要给napcat不然发送图片会有问题
     image: mlikiowa/napcat-docker:latest
 
   mongodb:
@@ -39,7 +39,8 @@ services:
       - mongodb
       - napcat
     volumes:
-      - maimbotCONFIG:/MaiMBot/config
+      - napcatCONFIG:/MaiMBot/napcat # 自动根据配置中的qq号创建ws反向客户端配置
+      - ./bot_config.toml:/MaiMBot/config/bot_config.toml
       - maimbotDATA:/MaiMBot/data
       - ./.env.prod:/MaiMBot/.env.prod
     image: sengokucola/maimbot:latest

--- a/template.env
+++ b/template.env
@@ -5,7 +5,7 @@ PORT=8080
 PLUGINS=["src2.plugins.chat"]
 
 # 默认配置
-MONGODB_HOST=127.0.0.1
+MONGODB_HOST=127.0.0.1 # 如果工作在Docker下，请改成 MONGODB_HOST=mongodb
 MONGODB_PORT=27017
 DATABASE_NAME=MegBot
 


### PR DESCRIPTION
feat: 将 napcatCONFIG 卷引入 maimbot，方便自动增加反向ws客户端
feat: 增加 docker 部署说明

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

向 maimbot 引入 napcatCONFIG 卷，以方便自动添加反向 WS 客户端，并添加 Docker 部署说明。

部署：
- 向 maimbot 引入 napcatCONFIG 卷，以方便自动添加反向 WS 客户端。
- 添加 Docker 部署说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce napcatCONFIG volume to maimbot to facilitate the automatic addition of reverse WS clients and add Docker deployment instructions.

Deployment:
- Introduce napcatCONFIG volume to maimbot to facilitate the automatic addition of reverse WS clients.
- Add Docker deployment instructions.

</details>