### PR TITLE
Feat/支持流式输出模型功能debug

### DIFF
--- a/src/plugins/models/utils_model.py
+++ b/src/plugins/models/utils_model.py
@@ -253,7 +253,7 @@ class LLM_request:
     async def _build_payload(self, prompt: str, image_base64: str = None) -> dict:
         """构建请求体"""
         # 复制一份参数，避免直接修改 self.params
-        params_copy = self._transform_parameters(self.model_name, self.params)
+        params_copy = self._transform_parameters(self.params)
         if image_base64:
             payload = {
                 "model": self.model_name,


### PR DESCRIPTION
将模型参数处理提取出来作为单独的函数
添加了一行注释
将OpenAI CoT模型列表中错误的”o1“修改为正确的”o1-preview“
修改了上个pr中错误的传参

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

重构了模型参数处理，将其放入一个单独的函数中，并修正了 OpenAI CoT 模型的参数传递。

增强功能：
- 将模型参数转换提取到一个专用函数中，以实现更好的组织和可重用性。
- 修正了 OpenAI CoT 模型列表，以包含正确的模型名称 'o1-preview' 而不是 'o1'。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactors the model parameter handling into a separate function and corrects parameter passing for OpenAI CoT models.

Enhancements:
- Extracts model parameter transformation into a dedicated function for better organization and reusability.
- Corrects the OpenAI CoT model list to include the correct model name 'o1-preview' instead of 'o1'.

</details>