### PR TITLE
fix: 强制批处理文件使用CRLF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.bat text eol=crlf
+*.cmd text eol=crlf

--- a/run_windows.bat
+++ b/run_windows.bat
@@ -47,11 +47,12 @@ if not exist "venv\" (
 
     call venv\Scripts\activate.bat
 
-    echo 正在安装依赖...
-    pip install -r requirements.txt
 ) else (
     call venv\Scripts\activate.bat
 )
+
+echo 正在更新依赖...
+pip install -r requirements.txt
 
 echo 当前代理设置：
 echo HTTP_PROXY=%HTTP_PROXY%


### PR DESCRIPTION
typo: 优化依赖更新

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

确保批处理文件使用 CRLF 换行符并更新依赖项。

杂项：
- 强制批处理文件使用 CRLF 换行符。
- 更新依赖项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensures batch files use CRLF line endings and updates dependencies.

Chores:
- Enforce CRLF line endings for batch files.
- Update dependencies.

</details>