### PR TITLE
修改temperature拼写错误

### DIFF
--- a/src/plugins/models/utils_model.py
+++ b/src/plugins/models/utils_model.py
@@ -244,7 +244,7 @@ class LLM_request:
         models_needing_transformation = ["o3-mini", "o1-mini", "o1-preview", "o1-2024-12-17", "o1-preview-2024-09-12", "o3-mini-2025-01-31", "o1-mini-2024-09-12"]
         if self.model_name.lower() in models_needing_transformation:
             # 删除 'temprature' 参数（如果存在）
-            new_params.pop("temprature", None)
+            new_params.pop("temperature", None)
             # 如果存在 'max_tokens'，则重命名为 'max_completion_tokens'
             if "max_tokens" in new_params:
                 new_params["max_completion_tokens"] = new_params.pop("max_tokens")


### PR DESCRIPTION
修改一个拼写错误，现在它可以正确的删除temperature参数，从而正确使用OpenAI系列模型了，我对我糟糕的英语拼写表示非常抱歉

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复:
- 修复了 'temperature' 参数的拼写错误，确保在使用 OpenAI 模型时能正确移除该参数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fixes a spelling error for the 'temperature' parameter, ensuring it is correctly removed when using OpenAI models.

</details>