### PR TITLE
fix: time.tzset 仅在类 Unix 系统可用

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -5,6 +5,7 @@ import time
 from dotenv import load_dotenv
 from loguru import logger
 from nonebot.adapters.onebot.v11 import Adapter
+import platform
 
 # 获取没有加载env时的环境变量
 env_mask = {key: os.getenv(key) for key in os.environ}
@@ -117,7 +118,8 @@ def scan_provider(env_config: dict):
 if __name__ == "__main__":
     # 利用 TZ 环境变量设定程序工作的时区
     # 仅保证行为一致，不依赖 localtime()，实际对生产环境几乎没有作用
-    time.tzset()
+    if platform.system().lower() != 'windows':
+        time.tzset()
 
     easter_egg()
     init_config()


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复：
- 修复了在 Windows 系统上调用 `time.tzset()` 的 bug，该函数在 Windows 系统上不受支持。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fixes a bug where time.tzset() was called on Windows systems, which is not supported.

</details>