### PR TITLE
fix: 使配置文件里的 llm_emotion_judge 生效

### DIFF
--- a/src/plugins/chat/emoji_manager.py
+++ b/src/plugins/chat/emoji_manager.py
@@ -33,7 +33,7 @@ class EmojiManager:
         self.db = Database.get_instance()
         self._scan_task = None
         self.vlm = LLM_request(model=global_config.vlm, temperature=0.3, max_tokens=1000)
-        self.llm_emotion_judge = LLM_request(model=global_config.llm_normal_minor, max_tokens=60,temperature=0.8) #更高的温度，更少的token（后续可以根据情绪来调整温度）
+        self.llm_emotion_judge = LLM_request(model=global_config.llm_emotion_judge, max_tokens=60,temperature=0.8) #更高的温度，更少的token（后续可以根据情绪来调整温度）
         
     def _ensure_emoji_dir(self):
         """确保表情存储目录存在"""


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 摘要：

## Sourcery 总结

Bug 修复：
- 修复了一个 bug，该 bug 导致情感判断器使用了错误的配置选项 `llm_normal_minor`，正确的选项应该是 `llm_emotion_judge`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fixes a bug where the `llm_normal_minor` config option was being used instead of `llm_emotion_judge` for the emotion judge.

</details>