### PR TITLE
fix: 更新情感判断模型配置（使配置文件里的 llm_emotion_judge 生效）

### DIFF
--- a/src/plugins/chat/emoji_manager.py
+++ b/src/plugins/chat/emoji_manager.py
@@ -33,7 +33,7 @@ class EmojiManager:
         self.db = Database.get_instance()
         self._scan_task = None
         self.vlm = LLM_request(model=global_config.vlm, temperature=0.3, max_tokens=1000)
-        self.llm_emotion_judge = LLM_request(model=global_config.llm_normal_minor, max_tokens=60,temperature=0.8) #更高的温度，更少的token（后续可以根据情绪来调整温度）
+        self.llm_emotion_judge = LLM_request(model=global_config.llm_emotion_judge, max_tokens=60,temperature=0.8) #更高的温度，更少的token（后续可以根据情绪来调整温度）
         
     def _ensure_emoji_dir(self):
         """确保表情存储目录存在"""


### PR DESCRIPTION
发现配置文件里的llm_emotion_judge不生效，检查代码发现是写错了...（下面让ai帮我总结）

好的，这是将提供的 pull request 摘要翻译成中文的结果：

## Sourcery 总结

Bug 修复:
- 修复了 `llm_emotion_judge` 模型的配置加载问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fixes the configuration loading for the llm_emotion_judge model.

</details>