### PR TITLE
feat: 优化willing_manager逻辑，增加回复保底概率

### DIFF
--- a/src/plugins/chat/willing_manager.py
+++ b/src/plugins/chat/willing_manager.py
@@ -1,6 +1,6 @@
 import asyncio
-from .config import global_config
 from loguru import logger
+from .config import global_config
 
 
 class WillingManager:
@@ -8,74 +8,100 @@ class WillingManager:
         self.group_reply_willing = {}  # 存储每个群的回复意愿
         self._decay_task = None
         self._started = False
-        
+        self.min_reply_willing = 0.01
+        self.attenuation_coefficient = 0.75
+
     async def _decay_reply_willing(self):
         """定期衰减回复意愿"""
         while True:
             await asyncio.sleep(5)
             for group_id in self.group_reply_willing:
-                self.group_reply_willing[group_id] = max(0, self.group_reply_willing[group_id] * 0.6)
-                
+                self.group_reply_willing[group_id] = max(
+                    self.min_reply_willing,
+                    self.group_reply_willing[group_id] * self.attenuation_coefficient
+                )
+
     def get_willing(self, group_id: int) -> float:
         """获取指定群组的回复意愿"""
         return self.group_reply_willing.get(group_id, 0)
-    
+
     def set_willing(self, group_id: int, willing: float):
         """设置指定群组的回复意愿"""
         self.group_reply_willing[group_id] = willing
-        
-    def change_reply_willing_received(self, group_id: int, topic: str, is_mentioned_bot: bool, config, user_id: int = None, is_emoji: bool = False, interested_rate: float = 0) -> float:
-        """改变指定群组的回复意愿并返回回复概率"""
+
+    def change_reply_willing_received(self, group_id: int, topic: str, is_mentioned_bot: bool, config,
+                                      user_id: int = None, is_emoji: bool = False, interested_rate: float = 0) -> float:
+
+        # 若非目标回复群组，则直接return
+        if group_id not in config.talk_allowed_groups:
+            reply_probability = 0
+            return reply_probability
+
         current_willing = self.group_reply_willing.get(group_id, 0)
-        
-        # print(f"初始意愿: {current_willing}")
-        if is_mentioned_bot and current_willing < 1.0:
-            current_willing += 0.9
-            logger.info(f"被提及, 当前意愿: {current_willing}")
-        elif is_mentioned_bot:
-            current_willing += 0.05
-            logger.info(f"被重复提及, 当前意愿: {current_willing}")
-        
+
+        logger.debug(f"[{group_id}]的初始回复意愿: {current_willing}")
+
+        # 根据消息类型（被cue/表情包）调控
+        if is_mentioned_bot:
+            current_willing = min(
+                3.0,
+                current_willing + 0.9
+            )
+            logger.debug(f"被提及, 当前意愿: {current_willing}")
+
         if is_emoji:
             current_willing *= 0.1
-            logger.info(f"表情包, 当前意愿: {current_willing}")
-        
-        logger.debug(f"放大系数_interested_rate: {global_config.response_interested_rate_amplifier}")
-        interested_rate *= global_config.response_interested_rate_amplifier #放大回复兴趣度
-        if interested_rate > 0.4:
-            # print(f"兴趣度: {interested_rate}, 当前意愿: {current_willing}")
-            current_willing += interested_rate-0.4
-        
-        current_willing *= global_config.response_willing_amplifier #放大回复意愿
-        # print(f"放大系数_willing: {global_config.response_willing_amplifier}, 当前意愿: {current_willing}")
-        
-        reply_probability = max((current_willing - 0.45) * 2, 0)
-        if group_id not in config.talk_allowed_groups:
-            current_willing = 0
-            reply_probability = 0
-            
+            logger.debug(f"表情包, 当前意愿: {current_willing}")
+
+        # 兴趣放大系数，若兴趣 > 0.4则增加回复概率
+        interested_rate_amplifier = global_config.response_interested_rate_amplifier
+        logger.debug(f"放大系数_interested_rate: {interested_rate_amplifier}")
+        interested_rate *= interested_rate_amplifier
+
+        current_willing += max(
+            0.0,
+            interested_rate - 0.4
+        )
+
+        # 回复意愿系数调控，独立乘区
+        willing_amplifier = max(
+            global_config.response_willing_amplifier,
+            self.min_reply_willing
+        )
+        current_willing *= willing_amplifier
+        logger.debug(f"放大系数_willing: {global_config.response_willing_amplifier}, 当前意愿: {current_willing}")
+
+        # 回复概率迭代，保底0.01回复概率
+        reply_probability = max(
+            (current_willing - 0.45) * 2,
+            self.min_reply_willing
+        )
+
+        # 降低目标低频群组回复概率
+        down_frequency_rate = max(
+            1.0,
+            global_config.down_frequency_rate
+        )
         if group_id in config.talk_frequency_down_groups:
-            reply_probability = reply_probability / global_config.down_frequency_rate
+            reply_probability = reply_probability / down_frequency_rate
 
         reply_probability = min(reply_probability, 1)
-        if reply_probability < 0:
-            reply_probability = 0
-            
-            
+
         self.group_reply_willing[group_id] = min(current_willing, 3.0)
+        logger.debug(f"当前群组{group_id}回复概率：{reply_probability}")
         return reply_probability
-    
+
     def change_reply_willing_sent(self, group_id: int):
         """开始思考后降低群组的回复意愿"""
         current_willing = self.group_reply_willing.get(group_id, 0)
         self.group_reply_willing[group_id] = max(0, current_willing - 2)
-        
+
     def change_reply_willing_after_sent(self, group_id: int):
         """发送消息后提高群组的回复意愿"""
         current_willing = self.group_reply_willing.get(group_id, 0)
         if current_willing < 1:
             self.group_reply_willing[group_id] = min(1, current_willing + 0.2)
-        
+
     async def ensure_started(self):
         """确保衰减任务已启动"""
         if not self._started:
@@ -83,5 +109,6 @@ class WillingManager:
                 self._decay_task = asyncio.create_task(self._decay_reply_willing())
             self._started = True
 
+
 # 创建全局实例
-willing_manager = WillingManager() 
+willing_manager = WillingManager()


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

改进了管理机器人在聊天群组中回复意愿的逻辑，增加了最小回复概率并调整了衰减系数。

增强功能：
- 增加最小回复概率，以确保机器人始终有机会回复。
- 调整衰减系数，以控制机器人的回复意愿随时间降低的速度。
- 重构回复概率计算，以包含最小回复概率和调整后的衰减系数。
- 增加调试日志，以跟踪每个群组的回复意愿和概率。
- 根据消息类型（提及、表情符号）和用户兴趣调整回复概率。
- 增加配置选项，以降低低频群组中的回复概率。
- 将回复概率上限设置为 1。
- 增加意愿放大器的最小值，以确保它永远不为零。
- 增加配置选项，以降低低频群组中的回复概率。
- 增加意愿放大器的最小值，以确保它永远不为零。
- 增加配置选项，以降低低频群组中的回复概率。
- 增加意愿放大器的最小值，以确保它永远不为零。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improves the logic for managing the bot's willingness to reply in chat groups by adding a minimum reply probability and adjusting the attenuation coefficient.

Enhancements:
- Adds a minimum reply probability to ensure the bot always has a chance to respond.
- Adjusts the attenuation coefficient to control how quickly the bot's willingness to reply decreases over time.
- Refactors the reply probability calculation to incorporate the minimum reply probability and the adjusted attenuation coefficient.
- Adds debug logs to track the reply willingness and probability for each group.
- Adjusts reply probability based on message type (mentions, emojis) and user interest.
- Adds a configuration option to reduce reply probability in low-frequency groups.
- Caps the reply probability at 1.
- Adds a minimum value to the willing amplifier to ensure it is never zero.
- Adds a configuration option to reduce reply probability in low-frequency groups.
- Adds a minimum value to the willing amplifier to ensure it is never zero.
- Adds a configuration option to reduce reply probability in low-frequency groups.
- Adds a minimum value to the willing amplifier to ensure it is never zero.

</details>