### PR TITLE
config.MONGODB_PORT应该int

### DIFF
--- a/src/plugins/memory_system/memory.py
+++ b/src/plugins/memory_system/memory.py
@@ -708,7 +708,7 @@ start_time = time.time()
 
 Database.initialize(
     host= config.MONGODB_HOST,
-    port= config.MONGODB_PORT,
+    port=int(config.MONGODB_PORT),
     db_name=  config.DATABASE_NAME,
     username= config.MONGODB_USERNAME,
     password= config.MONGODB_PASSWORD,


### PR DESCRIPTION
不然报错

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复：
- 修复了 MongoDB 端口不是整数时发生的错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fixes an error that occurs when the MongoDB port is not an integer.

</details>