### PR TITLE
feat: 精简日志，禁用Uvicorn/NoneBot默认日志；启动方式改为显示加载uvicorn，以便优雅shutdown

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,9 +1,12 @@
+import asyncio
 import os
 import shutil
 import sys
 
 import nonebot
 import time
+
+import uvicorn
 from dotenv import load_dotenv
 from loguru import logger
 from nonebot.adapters.onebot.v11 import Adapter
@@ -11,6 +14,8 @@ import platform
 
 # 获取没有加载env时的环境变量
 env_mask = {key: os.getenv(key) for key in os.environ}
+
+uvicorn_server = None
 
 
 def easter_egg():
@@ -100,8 +105,10 @@ def load_logger():
                "#777777>|</> <cyan>{name:.<8}</cyan>:<cyan>{function:.<8}</cyan>:<cyan>{line: >4}</cyan> <fg "
                "#777777>-</> <level>{message}</level>",
         colorize=True,
-        level=os.getenv("LOG_LEVEL", "DEBUG")  # 根据环境设置日志级别，默认为INFO
+        level=os.getenv("LOG_LEVEL", "INFO"),  # 根据环境设置日志级别，默认为INFO
+        filter=lambda record: "nonebot" not in record["name"]
     )
+
 
 
 def scan_provider(env_config: dict):
@@ -138,7 +145,39 @@ def scan_provider(env_config: dict):
             raise ValueError(f"请检查 '{provider_name}' 提供商配置是否丢失 BASE_URL 或 KEY 环境变量")
 
 
-if __name__ == "__main__":
+async def graceful_shutdown():
+    try:
+        global uvicorn_server
+        if uvicorn_server:
+            uvicorn_server.force_exit = True  # 强制退出
+            await uvicorn_server.shutdown()
+
+        tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+    except Exception as e:
+        logger.error(f"麦麦关闭失败: {e}")
+
+
+async def uvicorn_main():
+    global uvicorn_server
+    config = uvicorn.Config(
+        app="__main__:app",
+        host=os.getenv("HOST", "127.0.0.1"),
+        port=int(os.getenv("PORT", 8080)),
+        reload=os.getenv("ENVIRONMENT") == "dev",
+        timeout_graceful_shutdown=5,
+        log_config=None,
+        access_log=False
+    )
+    server = uvicorn.Server(config)
+    uvicorn_server = server
+    await server.serve()
+
+
+def raw_main():
     # 利用 TZ 环境变量设定程序工作的时区
     # 仅保证行为一致，不依赖 localtime()，实际对生产环境几乎没有作用
     if platform.system().lower() != 'windows':
@@ -165,10 +204,30 @@ if __name__ == "__main__":
     nonebot.init(**base_config, **env_config)
 
     # 注册适配器
+    global driver
     driver = nonebot.get_driver()
     driver.register_adapter(Adapter)
 
     # 加载插件
     nonebot.load_plugins("src/plugins")
 
-    nonebot.run()
+
+if __name__ == "__main__":
+
+    try:
+        raw_main()
+
+        global app
+        app = nonebot.get_asgi()
+
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(uvicorn_main())
+    except KeyboardInterrupt:
+        logger.warning("麦麦会努力做的更好的！正在停止中......")
+    except Exception as e:
+        logger.error(f"主程序异常: {e}")
+    finally:
+        loop.run_until_complete(graceful_shutdown())
+        loop.close()
+        logger.info("进程终止完毕，麦麦开始休眠......下次再见哦！")


### PR DESCRIPTION
好的，这是将 pull request 总结翻译成中文的结果：

## Sourcery 总结

重构了应用程序启动过程，直接使用 Uvicorn 以更好地控制关闭过程。通过禁用默认的 Uvicorn 和 NoneBot 日志来简化日志记录，并将默认日志级别设置为 INFO。增加了优雅关闭功能，以确保任务和 Uvicorn 服务器的正确终止。

增强功能：
- 重构应用程序启动过程，直接加载 Uvicorn，从而实现优雅关闭。
- 通过禁用默认的 Uvicorn 和 NoneBot 日志来简化日志配置。
- 改进关闭过程，以确保所有任务都被取消并且 Uvicorn 服务器已正确终止。
- 将默认日志级别设置为 INFO 以减少冗余信息。
- 添加过滤器到 logger 以排除 nonebot 日志

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactors the application startup to use Uvicorn directly for better control over the shutdown process. Simplifies logging by disabling default Uvicorn and NoneBot logs and sets the default log level to INFO. Adds graceful shutdown functionality to ensure proper termination of tasks and the Uvicorn server.

Enhancements:
- Refactor application startup to directly load Uvicorn, enabling graceful shutdowns.
- Simplify logging configuration by disabling default Uvicorn and NoneBot logs.
- Improve the shutdown process to ensure all tasks are cancelled and the Uvicorn server is properly terminated.
- Set the default log level to INFO to reduce verbosity.
- Add filter to logger to exclude nonebot logs

</details>