### PR TITLE
refactor: 使用 Base64 编码的表情包 CQ 码

### DIFF
--- a/src/plugins/chat/cq_code.py
+++ b/src/plugins/chat/cq_code.py
@@ -1,6 +1,5 @@
 import base64
 import html
-import os
 import time
 from dataclasses import dataclass
 from typing import Dict, Optional
@@ -17,7 +16,7 @@ from urllib3.util import create_urllib3_context
 from ..models.utils_model import LLM_request
 from .config import global_config
 from .mapper import emojimapper
-from .utils_image import storage_emoji, storage_image
+from .utils_image import image_path_to_base64, storage_emoji, storage_image
 from .utils_user import get_user_nickname
 
 driver = get_driver()
@@ -328,15 +327,10 @@ class CQCode:
         Returns:
             表情包CQ码字符串
         """
-        # 确保使用绝对路径
-        abs_path = os.path.abspath(file_path)
-        # 转义特殊字符
-        escaped_path = abs_path.replace('&', '&amp;') \
-            .replace('[', '&#91;') \
-            .replace(']', '&#93;') \
-            .replace(',', '&#44;')
+        base64_content = image_path_to_base64(file_path)
+
         # 生成CQ码，设置sub_type=1表示这是表情包
-        return f"[CQ:image,file=file:///{escaped_path},sub_type=1]"
+        return f"[CQ:image,file=base64://{base64_content},sub_type=1]"
 
 
 class CQCode_tool:


### PR DESCRIPTION
原先用的是本地文件地址发送图片，但经测试会在 macOS 上遇到权限问题（无法将 MaiMBot 存储的图片复制到 QQ 应用程序文件夹内），以及这边也有一个 [issue](https://github.com/SengokuCola/MaiMBot/issues/143) 疑似也跟这个实现有关。

本 PR 将本地文件地址更改为使用 Base64 编码进行表情包 CQ 码的生成，除了可以解决上面两个问题，还有可能允许 MaiMBot 与 NapCat 部署在不同设备上（未经测试）。

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

增强功能：
- 重构了表情 CQ 码的生成方式，使用 Base64 编码代替本地文件路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Refactor the generation of emoticons CQ codes to use Base64 encoding instead of local file paths.

</details>