### PR TITLE
fix: 图片保存路径不正确

### DIFF
--- a/src/plugins/chat/utils_image.py
+++ b/src/plugins/chat/utils_image.py
@@ -199,15 +199,6 @@ class ImageManager:
             logger.error(f"获取base64失败: {str(e)}")
             return None
             
-    async def save_base64_image(self, base64_str: str, description: str = None) -> Optional[str]:
-        """保存base64图像(带查重)
-        Args:
-            base64_str: base64字符串
-            description: 图像描述
-        Returns:
-            str: 保存路径,失败返回None
-        """
-        return await self.save_image(base64_str, description=description, is_base64=True)
         
     def check_url_exists(self, url: str) -> bool:
         """检查URL是否已存在
@@ -266,8 +257,8 @@ class ImageManager:
             if global_config.EMOJI_SAVE:
                 # 生成文件名和路径
                 timestamp = int(time.time())
-                filename = f"emoji_{timestamp}_{image_hash[:8]}.jpg"
-                file_path = os.path.join(self.IMAGE_DIR, filename)
+                filename = f"{timestamp}_{image_hash[:8]}.jpg"
+                file_path = os.path.join(self.IMAGE_DIR, 'emoji',filename)
                 
                 try:
                     # 保存文件
@@ -323,8 +314,8 @@ class ImageManager:
             if global_config.EMOJI_SAVE:
                 # 生成文件名和路径
                 timestamp = int(time.time())
-                filename = f"image_{timestamp}_{image_hash[:8]}.jpg"
-                file_path = os.path.join(self.IMAGE_DIR, filename)
+                filename = f"{timestamp}_{image_hash[:8]}.jpg"
+                file_path = os.path.join(self.IMAGE_DIR,'image', filename)
                 
                 try:
                     # 保存文件


### PR DESCRIPTION
火速修复

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复：
- 修复了表情符号和图片的图像保存路径，通过将 'emoji' 和 'image' 子目录添加到路径中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fixes the image saving path for emojis and images by adding the 'emoji' and 'image' subdirectories to the path.

</details>