### PR TITLE
bugfix&feat: 添加logger.debug输出开关,调整env文件生成逻辑

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -51,15 +51,15 @@ def init_env():
         with open(".env", "w") as f:
             f.write("ENVIRONMENT=prod")
 
-        # 检测.env.prod文件是否存在
-        if not os.path.exists(".env.prod"):
-            logger.error("检测到.env.prod文件不存在")
-            shutil.copy("template.env", "./.env.prod")
+    # 检测.env.prod文件是否存在
+    if not os.path.exists(".env.prod"):
+        logger.error("检测到.env.prod文件不存在")
+        shutil.copy("template.env", "./.env.prod")
 
     # 检测.env.dev文件是否存在，不存在的话直接复制生产环境配置
     if not os.path.exists(".env.dev"):
         logger.error("检测到.env.dev文件不存在")
-        shutil.copy(".env.prod", "./.env.dev")
+        shutil.copy("template.env", "./.env.dev")
 
     # 首先加载基础环境变量.env
     if os.path.exists(".env"):

--- a/src/plugins/chat/config.py
+++ b/src/plugins/chat/config.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
@@ -67,6 +68,7 @@ class BotConfig:
 
     enable_advance_output: bool = False  # 是否启用高级输出
     enable_kuuki_read: bool = True  # 是否启用读空气功能
+    enable_debug_output: bool = False  # 是否启用调试输出
 
     mood_update_interval: float = 1.0  # 情绪更新间隔 单位秒
     mood_decay_rate: float = 0.95  # 情绪衰减率
@@ -325,6 +327,7 @@ class BotConfig:
             others_config = parent["others"]
             config.enable_advance_output = others_config.get("enable_advance_output", config.enable_advance_output)
             config.enable_kuuki_read = others_config.get("enable_kuuki_read", config.enable_kuuki_read)
+            config.enable_debug_output = others_config.get("enable_debug_output", config.enable_debug_output)
 
         # 版本表达式：>=1.0.0,<2.0.0
         # 允许字段：func: method, support: str, notice: str, necessary: bool
@@ -419,4 +422,8 @@ global_config = BotConfig.load_config(config_path=bot_config_path)
 
 if not global_config.enable_advance_output:
     logger.remove()
-    pass
+    
+# 调试输出功能
+if global_config.enable_debug_output:
+    logger.remove()
+    logger.add(sys.stdout, level="DEBUG")

--- a/template/bot_config_template.toml
+++ b/template/bot_config_template.toml
@@ -100,6 +100,7 @@ word_replace_rate=0.006 # 整词替换概率
 [others]
 enable_advance_output = true # 是否启用高级输出
 enable_kuuki_read = true # 是否启用读空气功能
+enable_debug_output = false # 是否启用调试输出
 
 [groups]
 talk_allowed = [


### PR DESCRIPTION
## feat:
1. 添加一个默认关闭的enable_debug_output开关,用于控制logger输出debug信息

## bugfix:
修复了.env.prod和.env.dev复制逻辑,避免了某些case下无法正确生成对应文件的bug

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

添加了一个调试输出开关，并修复了生成 .env 文件的逻辑。

新特性：
- 添加了一个默认禁用的 `enable_debug_output` 开关，用于控制来自 logger 的调试信息的输出。

Bug 修复：
- 修复了 `.env.prod` 和 `.env.dev` 文件的复制逻辑，避免在某些情况下无法正确生成相应文件的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adds a debug output switch and fixes the logic for generating .env files.

New Features:
- Adds an enable_debug_output switch that is disabled by default to control the output of debug information from the logger.

Bug Fixes:
- Fixes the .env.prod and .env.dev copy logic to avoid issues where the corresponding files are not generated correctly in some cases.

</details>