### PR TITLE
feat: 新增运行时重载配置文件；新增根据不同环境(dev;prod)显示不同级别的log

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -51,15 +51,15 @@ def init_env():
         with open(".env", "w") as f:
             f.write("ENVIRONMENT=prod")
 
-    # 检测.env.prod文件是否存在
-    if not os.path.exists(".env.prod"):
-        logger.error("检测到.env.prod文件不存在")
-        shutil.copy("template.env", "./.env.prod")
+        # 检测.env.prod文件是否存在
+        if not os.path.exists(".env.prod"):
+            logger.error("检测到.env.prod文件不存在")
+            shutil.copy("template.env", "./.env.prod")
 
     # 检测.env.dev文件是否存在，不存在的话直接复制生产环境配置
     if not os.path.exists(".env.dev"):
         logger.error("检测到.env.dev文件不存在")
-        shutil.copy("template.env", "./.env.dev")
+        shutil.copy(".env.prod", "./.env.dev")
 
     # 首先加载基础环境变量.env
     if os.path.exists(".env"):
@@ -99,15 +99,25 @@ def load_env():
 
 def load_logger():
     logger.remove()  # 移除默认配置
-    logger.add(
-        sys.stderr,
-        format="<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> <fg #777777>|</> <level>{level: <7}</level> <fg "
-               "#777777>|</> <cyan>{name:.<8}</cyan>:<cyan>{function:.<8}</cyan>:<cyan>{line: >4}</cyan> <fg "
-               "#777777>-</> <level>{message}</level>",
-        colorize=True,
-        level=os.getenv("LOG_LEVEL", "INFO"),  # 根据环境设置日志级别，默认为INFO
-        filter=lambda record: "nonebot" not in record["name"]
-    )
+    if os.getenv("ENVIRONMENT") == "dev":
+        logger.add(
+            sys.stderr,
+            format="<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> <fg #777777>|</> <level>{level: <7}</level> <fg "
+                   "#777777>|</> <cyan>{name:.<8}</cyan>:<cyan>{function:.<8}</cyan>:<cyan>{line: >4}</cyan> <fg "
+                   "#777777>-</> <level>{message}</level>",
+            colorize=True,
+            level=os.getenv("LOG_LEVEL", "DEBUG"),  # 根据环境设置日志级别，默认为DEBUG
+        )
+    else:
+        logger.add(
+            sys.stderr,
+            format="<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> <fg #777777>|</> <level>{level: <7}</level> <fg "
+                "#777777>|</> <cyan>{name:.<8}</cyan>:<cyan>{function:.<8}</cyan>:<cyan>{line: >4}</cyan> <fg "
+                "#777777>-</> <level>{message}</level>",
+            colorize=True,
+            level=os.getenv("LOG_LEVEL", "INFO"),  # 根据环境设置日志级别，默认为INFO
+            filter=lambda record: "nonebot" not in record["name"]
+        )
 
 
 

--- a/src/plugins/config_reload/__init__.py
+++ b/src/plugins/config_reload/__init__.py
@@ -1,0 +1,10 @@
+from nonebot import get_app
+from .api import router
+from loguru import logger
+
+# 获取主应用实例并挂载路由
+app = get_app()
+app.include_router(router, prefix="/api")
+
+# 打印日志，方便确认API已注册
+logger.success("配置重载API已注册，可通过 /api/reload-config 访问")

--- a/src/plugins/config_reload/api.py
+++ b/src/plugins/config_reload/api.py
@@ -1,0 +1,17 @@
+from fastapi import APIRouter, HTTPException
+from src.plugins.chat.config import BotConfig
+import os
+
+# 创建APIRouter而不是FastAPI实例
+router = APIRouter()
+
+@router.post("/reload-config")
+async def reload_config():
+    try:
+        bot_config_path = os.path.join(BotConfig.get_config_dir(), "bot_config.toml")
+        global_config = BotConfig.load_config(config_path=bot_config_path)
+        return {"message": "配置重载成功", "status": "success"}
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"重载配置时发生错误: {str(e)}")

--- a/src/plugins/config_reload/test.py
+++ b/src/plugins/config_reload/test.py
@@ -1,0 +1,3 @@
+import requests
+response = requests.post("http://localhost:8080/api/reload-config")
+print(response.json())


### PR DESCRIPTION
重载配置文件通过api端口触发，route到bot.py的uvicorn上，默认配置下通过post请求http://127.0.0.1:8080/api/reload-config触发

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

增加了在运行时通过 API 端点重新加载机器人配置的功能，并为不同的环境配置了不同的日志级别。

新功能：
- 引入了一个 API 端点，用于在运行时重新加载机器人配置。
- 根据环境配置不同的日志级别（开发环境为 DEBUG，生产环境为 INFO）。

测试：
- 添加了一个测试脚本来验证配置重新加载 API 端点。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adds the ability to reload the bot configuration at runtime via an API endpoint and configures different log levels for different environments.

New Features:
- Introduces an API endpoint to reload the bot configuration at runtime.
- Configures different log levels (DEBUG for development, INFO for production) based on the environment.

Tests:
- Adds a test script to verify the configuration reload API endpoint.

</details>