### PR TITLE
close SengokuCola/MaiMBot#225 让麦麦可以正确读取分享卡片

### DIFF
--- a/src/plugins/chat/message.py
+++ b/src/plugins/chat/message.py
@@ -80,7 +80,10 @@ class MessageRecv(Message):
             pattern = r'\[CQ:json,data=(?P<json_data>.+?)\]'
             match = re.search(pattern, message_dict.get('raw_message',''))
             raw_json = html.unescape(match.group('json_data'))
-            json_message = json.loads(raw_json)
+            try:
+                json_message = json.loads(raw_json)
+            except json.JSONDecodeError:
+                json_message = {}
             message_segment['data'] = json_message.get('prompt','')
 
         self.message_segment = Seg.from_dict(message_dict.get('message_segment', {}))

--- a/src/plugins/chat/message.py
+++ b/src/plugins/chat/message.py
@@ -1,4 +1,7 @@
 import time
+import html
+import re
+import json
 from dataclasses import dataclass
 from typing import Dict, ForwardRef, List, Optional, Union
 
@@ -69,6 +72,17 @@ class MessageRecv(Message):
             message_dict: MessageCQ序列化后的字典
         """
         self.message_info = BaseMessageInfo.from_dict(message_dict.get('message_info', {}))
+
+        message_segment = message_dict.get('message_segment', {})
+
+        if message_segment.get('data','') == '[json]':
+            # 提取json消息中的展示信息
+            pattern = r'\[CQ:json,data=(?P<json_data>.+?)\]'
+            match = re.search(pattern, message_dict.get('raw_message',''))
+            raw_json = html.unescape(match.group('json_data'))
+            json_message = json.loads(raw_json)
+            message_segment['data'] = json_message.get('prompt','')
+
         self.message_segment = Seg.from_dict(message_dict.get('message_segment', {}))
         self.raw_message = message_dict.get('raw_message')
         


### PR DESCRIPTION
现在麦麦可以读取到正确的json卡片信息的标题。

测试过知乎、b站、NGA的分享卡片都可以正确读取到标题。

好的，这是翻译成中文的 pull request 摘要：

## Sourcery 总结

Bug 修复：
- 修复了机器人无法从 JSON 卡片消息中读取标题的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where the bot was unable to read the title from JSON card messages.

</details>