### PR TITLE
记忆节点非空判断

### DIFF
--- a/src/plugins/memory_system/memory_manual_build.py
+++ b/src/plugins/memory_system/memory_manual_build.py
@@ -550,6 +550,9 @@ class Hippocampus:
         # 计算要检查的节点数量
         check_count = max(1, int(len(all_nodes) * percentage))
         # 随机选择节点
+        if len(all_nodes) <= 0:
+            logger.info("没有节点可以遗忘")
+            return
         nodes_to_check = random.sample(all_nodes, check_count)
         
         forgotten_nodes = []


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

添加了一项检查，以确保在尝试忘记节点之前存在要忘记的节点，从而防止节点列表为空时可能发生的错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adds a check to ensure there are nodes to forget before attempting to forget them, preventing potential errors when the node list is empty.

</details>