### PR TITLE
恢复ruff设置

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -5,3 +5,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3


### PR DESCRIPTION
rt

好的，这是翻译成中文的 pull request 摘要：

## Sourcery 总结

CI:
- 重新启用 CI 工作流程中的 Ruff action 以运行 Ruff 检查。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Re-enables the Ruff action in the CI workflow to run Ruff checks.

</details>