### PR TITLE
fix: ban_user_id在回复的情况下可能被绕过

### DIFF
--- a/src/plugins/chat/bot.py
+++ b/src/plugins/chat/bot.py
@@ -120,7 +120,10 @@ class ChatBot:
         # 用户屏蔽,不区分私聊/群聊
         if event.user_id in global_config.ban_user_id:
             return
-
+        
+        if event.reply and hasattr(event.reply, 'sender') and hasattr(event.reply.sender, 'user_id') and event.reply.sender.user_id in global_config.ban_user_id:
+            logger.debug(f"跳过处理回复来自被ban用户 {event.reply.sender.user_id} 的消息")
+            return
         # 处理私聊消息
         if isinstance(event, PrivateMessageEvent):
             if not global_config.enable_friend_chat:  # 私聊过滤


### PR DESCRIPTION
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [ ] 本次更新 **包含破坏性变更**（如数据库结构变更、配置文件修改等）
3. - [x] 本次更新是否经过测试
4. 请填写破坏性更新的具体内容（如有）:
5. 请简要说明本次更新的内容和目的：
  解决可能ban_user_id在回复情况下 同样会接收并处理的情况
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复：
- 修复了一个 bug，该 bug 导致机器人会处理对被封禁用户消息的回复。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fixes a bug where the bot would process messages that were replies to messages from banned users.

</details>