### PR TITLE
fix: 使用os.path.join代替硬编码路径分隔符

### DIFF
--- a/src/plugins/chat/emoji_manager.py
+++ b/src/plugins/chat/emoji_manager.py
@@ -25,7 +25,7 @@ image_manager = ImageManager()
 
 class EmojiManager:
     _instance = None
-    EMOJI_DIR = "data/emoji"  # 表情包存储目录
+    EMOJI_DIR = os.path.join("data", "emoji")  # 表情包存储目录
 
     def __new__(cls):
         if cls._instance is None:
@@ -211,7 +211,7 @@ class EmojiManager:
     async def scan_new_emojis(self):
         """扫描新的表情包"""
         try:
-            emoji_dir = "data/emoji"
+            emoji_dir = self.EMOJI_DIR
             os.makedirs(emoji_dir, exist_ok=True)
 
             # 获取所有支持的图片文件


### PR DESCRIPTION
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [ ] 本次更新 **包含破坏性变更**（如数据库结构变更、配置文件修改等）
3. - [x] 本次更新是否经过测试
4. 请填写破坏性更新的具体内容（如有）:
5. 请简要说明本次更新的内容和目的：
**更新内容和目的**
将"data/emoji"替换为os.path.join("data", "emoji")，提升跨平台兼容性
**问题背景**，
原代码在 Windows 下可能因硬编码 / 导致存储表情包的时候路径错误（如 data/emoji\1741834175_71aa150f.gif 混合斜杠）
![image](https://github.com/user-attachments/assets/9cfcf028-7bf3-4578-8b65-08406447d622)
修复后再测试就没问题了
![image](https://github.com/user-attachments/assets/7d89499d-064b-4468-b443-31efdb84323a)

# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:
