### PR TITLE
修复回复消息没有正常发送的问题

### DIFF
--- a/src/plugins/chat/message.py
+++ b/src/plugins/chat/message.py
@@ -324,7 +324,7 @@ class MessageSending(MessageProcessBase):
             self.message_segment = Seg(
                 type="seglist",
                 data=[
-                    Seg(type="reply", data=reply.message_info.message_id),
+                    Seg(type="reply", data=self.reply.message_info.message_id),
                     self.message_segment,
                 ],
             )

--- a/src/plugins/chat/message_sender.py
+++ b/src/plugins/chat/message_sender.py
@@ -181,9 +181,7 @@ class MessageManager:
                     and not message_earliest.is_private_message()  # 避免在私聊时插入reply
                 ):
                     message_earliest.set_reply()
-                    await message_sender.send_message(message_earliest)
-                else:
-                    await message_sender.send_message(message_earliest)
+                await message_sender.send_message(message_earliest)
                 await message_earliest.process()
 
                 print(
@@ -210,9 +208,7 @@ class MessageManager:
                             and not message_earliest.is_private_message()  # 避免在私聊时插入reply
                         ):
                             msg.set_reply()
-                            await message_sender.send_message(msg.set_reply())
-                        else:
-                            await message_sender.send_message(msg)
+                        await message_sender.send_message(msg)
 
                         # if msg.is_emoji:
                         #     msg.processed_plain_text = "[表情包]"

--- a/src/plugins/chat/message_sender.py
+++ b/src/plugins/chat/message_sender.py
@@ -180,7 +180,8 @@ class MessageManager:
                     and message_earliest.update_thinking_time() > 30
                     and not message_earliest.is_private_message()  # 避免在私聊时插入reply
                 ):
-                    await message_sender.send_message(message_earliest.set_reply())
+                    message_earliest.set_reply()
+                    await message_sender.send_message(message_earliest)
                 else:
                     await message_sender.send_message(message_earliest)
                 await message_earliest.process()
@@ -208,6 +209,7 @@ class MessageManager:
                             and msg.update_thinking_time() > 30
                             and not message_earliest.is_private_message()  # 避免在私聊时插入reply
                         ):
+                            msg.set_reply()
                             await message_sender.send_message(msg.set_reply())
                         else:
                             await message_sender.send_message(msg)


### PR DESCRIPTION
set_reply不存在返回值，导致回复消息发送为空
单独set_reply后发送msg本体即可

# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [ ] 本次更新 **包含破坏性变更**（如数据库结构变更、配置文件修改等）
3. - [x] 本次更新是否经过测试
4. - [x] 请**不要**在数据库中添加group_id字段，这会影响本项目对其他平台的兼容
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：修复set_reply后消息没有正常发送的问题
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- 修复前，set_reply后send_message处输出为空
![image](https://github.com/user-attachments/assets/7599e2fa-0834-4a57-ac70-723521a0e3b0)

- **附加信息**:
