### PR TITLE
refactor: 重构“戳一戳”的处理逻辑

### DIFF
--- a/src/plugins/chat/bot.py
+++ b/src/plugins/chat/bot.py
@@ -52,94 +52,15 @@ class ChatBot:
         if not self._started:
             self._started = True
 
-    async def handle_notice(self, event: NoticeEvent, bot: Bot) -> None:
-        """处理收到的通知"""
-        # 戳一戳通知
-        if isinstance(event, PokeNotifyEvent):
-            # 不处理其他人的戳戳
-            if not event.is_tome():
-                return
-
-            # 用户屏蔽,不区分私聊/群聊
-            if event.user_id in global_config.ban_user_id:
-                return
-
-            reply_poke_probability = 1.0  # 回复戳一戳的概率，如果要改可以在这里改，暂不提取到配置文件
-
-            if random() < reply_poke_probability:
-                raw_message = "[戳了戳]你"  # 默认类型
-                if info := event.raw_info:
-                    poke_type = info[2].get("txt", "戳了戳")  # 戳戳类型，例如“拍一拍”、“揉一揉”、“捏一捏”
-                    custom_poke_message = info[4].get("txt", "")  # 自定义戳戳消息，若不存在会为空字符串
-                    raw_message = f"[{poke_type}]你{custom_poke_message}"
-
-                raw_message += "（这是一个类似摸摸头的友善行为，而不是恶意行为，请不要作出攻击发言）"
-                await self.directly_reply(raw_message, event.user_id, event.group_id)
-
-    async def handle_message(self, event: MessageEvent, bot: Bot) -> None:
-        """处理收到的消息"""
-
-        self.bot = bot  # 更新 bot 实例
-
-        # 用户屏蔽,不区分私聊/群聊
-        if event.user_id in global_config.ban_user_id:
-            return
-
-        if (
-            event.reply
-            and hasattr(event.reply, "sender")
-            and hasattr(event.reply.sender, "user_id")
-            and event.reply.sender.user_id in global_config.ban_user_id
-        ):
-            logger.debug(f"跳过处理回复来自被ban用户 {event.reply.sender.user_id} 的消息")
-            return
-        # 处理私聊消息
-        if isinstance(event, PrivateMessageEvent):
-            if not global_config.enable_friend_chat:  # 私聊过滤
-                return
-            else:
-                try:
-                    user_info = UserInfo(
-                        user_id=event.user_id,
-                        user_nickname=(await bot.get_stranger_info(user_id=event.user_id, no_cache=True))["nickname"],
-                        user_cardname=None,
-                        platform="qq",
-                    )
-                except Exception as e:
-                    logger.error(f"获取陌生人信息失败: {e}")
-                    return
-                logger.debug(user_info)
-
-                # group_info = GroupInfo(group_id=0, group_name="私聊", platform="qq")
-                group_info = None
-
-        # 处理群聊消息
-        else:
-            # 白名单设定由nontbot侧完成
-            if event.group_id:
-                if event.group_id not in global_config.talk_allowed_groups:
-                    return
-
-            user_info = UserInfo(
-                user_id=event.user_id,
-                user_nickname=event.sender.nickname,
-                user_cardname=event.sender.card or None,
-                platform="qq",
-            )
-
-            group_info = GroupInfo(group_id=event.group_id, group_name=None, platform="qq")
-
-        # group_info = await bot.get_group_info(group_id=event.group_id)
-        # sender_info = await bot.get_group_member_info(group_id=event.group_id, user_id=event.user_id, no_cache=True)
-
-        message_cq = MessageRecvCQ(
-            message_id=event.message_id,
-            user_info=user_info,
-            raw_message=str(event.original_message),
-            group_info=group_info,
-            reply_message=event.reply,
-            platform="qq",
-        )
+    async def message_process(self, message_cq: MessageRecvCQ) -> None:
+        """处理转化后的统一格式消息
+        1. 过滤消息
+        2. 记忆激活
+        3. 意愿激活
+        4. 生成回复并发送
+        5. 更新关系
+        6. 更新情绪
+        """
         message_json = message_cq.to_dict()
 
         # 进入maimbot
@@ -340,71 +261,124 @@ class ChatBot:
             #     chat_stream=chat
             # )
 
-    async def directly_reply(self, raw_message: str, user_id: int, group_id: int):
-        """
-        直接回复发来的消息，不经过意愿管理器
-        """
+    async def handle_notice(self, event: NoticeEvent, bot: Bot) -> None:
+        """处理收到的通知"""
+        # 戳一戳通知
+        if isinstance(event, PokeNotifyEvent):
+            # 不处理其他人的戳戳
+            if not event.is_tome():
+                return
 
-        # 构造用户信息和群组信息
-        user_info = UserInfo(
-            user_id=user_id,
-            user_nickname=get_user_nickname(user_id) or None,
-            user_cardname=get_user_cardname(user_id) or None,
-            platform="qq",
-        )
-        group_info = GroupInfo(group_id=group_id, group_name=None, platform="qq")
+            # 用户屏蔽,不区分私聊/群聊
+            if event.user_id in global_config.ban_user_id:
+                return
+            
+            # 白名单模式
+            if event.group_id:
+                if event.group_id not in global_config.talk_allowed_groups:
+                    return
+
+            raw_message = f"[戳了戳]{global_config.BOT_NICKNAME}"  # 默认类型
+            if info := event.raw_info:
+                poke_type = info[2].get("txt", "戳了戳")  # 戳戳类型，例如“拍一拍”、“揉一揉”、“捏一捏”
+                custom_poke_message = info[4].get("txt", "")  # 自定义戳戳消息，若不存在会为空字符串
+                raw_message = f"[{poke_type}]{global_config.BOT_NICKNAME}{custom_poke_message}"
+
+                raw_message += "（这是一个类似摸摸头的友善行为，而不是恶意行为，请不要作出攻击发言）"
+
+            user_info = UserInfo(
+                user_id=event.user_id,
+                user_nickname=(await bot.get_stranger_info(user_id=event.user_id, no_cache=True))["nickname"],
+                user_cardname=None,
+                platform="qq",
+            )
+            
+            if event.group_id:
+                group_info = GroupInfo(group_id=event.group_id, group_name=None, platform="qq")
+            else:
+                group_info = None
+
+            message_cq = MessageRecvCQ(
+                message_id=0,
+                user_info=user_info,
+                raw_message=str(raw_message),
+                group_info=group_info,
+                reply_message=None,
+                platform="qq",
+            )
+        else:
+            # 在此条之上添加isinstance(event, NoticeEvent)的判断，以处理某种通知
+            # 其他通知，暂不处理
+            return
+
+        await self.message_process(message_cq)
+
+    async def handle_message(self, event: MessageEvent, bot: Bot) -> None:
+        """处理收到的消息"""
+
+        self.bot = bot  # 更新 bot 实例
+
+        # 用户屏蔽,不区分私聊/群聊
+        if event.user_id in global_config.ban_user_id:
+            return
+
+        if (
+            event.reply
+            and hasattr(event.reply, "sender")
+            and hasattr(event.reply.sender, "user_id")
+            and event.reply.sender.user_id in global_config.ban_user_id
+        ):
+            logger.debug(f"跳过处理回复来自被ban用户 {event.reply.sender.user_id} 的消息")
+            return
+        # 处理私聊消息
+        if isinstance(event, PrivateMessageEvent):
+            if not global_config.enable_friend_chat:  # 私聊过滤
+                return
+            else:
+                try:
+                    user_info = UserInfo(
+                        user_id=event.user_id,
+                        user_nickname=(await bot.get_stranger_info(user_id=event.user_id, no_cache=True))["nickname"],
+                        user_cardname=None,
+                        platform="qq",
+                    )
+                except Exception as e:
+                    logger.error(f"获取陌生人信息失败: {e}")
+                    return
+                logger.debug(user_info)
+
+                # group_info = GroupInfo(group_id=0, group_name="私聊", platform="qq")
+                group_info = None
+
+        # 处理群聊消息
+        else:
+            # 白名单设定由nontbot侧完成
+            if event.group_id:
+                if event.group_id not in global_config.talk_allowed_groups:
+                    return
+
+            user_info = UserInfo(
+                user_id=event.user_id,
+                user_nickname=event.sender.nickname,
+                user_cardname=event.sender.card or None,
+                platform="qq",
+            )
+
+            group_info = GroupInfo(group_id=event.group_id, group_name=None, platform="qq")
+
+        # group_info = await bot.get_group_info(group_id=event.group_id)
+        # sender_info = await bot.get_group_member_info(group_id=event.group_id, user_id=event.user_id, no_cache=True)
 
         message_cq = MessageRecvCQ(
-            message_id=None,
+            message_id=event.message_id,
             user_info=user_info,
-            raw_message=raw_message,
+            raw_message=str(event.original_message),
             group_info=group_info,
-            reply_message=None,
+            reply_message=event.reply,
             platform="qq",
         )
-        message_json = message_cq.to_dict()
 
-        message = MessageRecv(message_json)
-        groupinfo = message.message_info.group_info
-        userinfo = message.message_info.user_info
-        messageinfo = message.message_info
-
-        chat = await chat_manager.get_or_create_stream(
-            platform=messageinfo.platform, user_info=userinfo, group_info=groupinfo
-        )
-        message.update_chat_stream(chat)
-        await message.process()
-
-        bot_user_info = UserInfo(
-            user_id=global_config.BOT_QQ,
-            user_nickname=global_config.BOT_NICKNAME,
-            platform=messageinfo.platform,
-        )
-
-        current_time = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(messageinfo.time))
-        logger.info(
-            f"[{current_time}][{chat.group_info.group_name if chat.group_info else '私聊'}]{chat.user_info.user_nickname}:"
-            f"{message.processed_plain_text}"
-        )
-
-        # 使用大模型生成回复
-        response, raw_content = await self.gpt.generate_response(message)
-
-        if response:
-            for msg in response:
-                message_segment = Seg(type="text", data=msg)
-
-                bot_message = MessageSending(
-                    message_id=None,
-                    chat_stream=chat,
-                    bot_user_info=bot_user_info,
-                    sender_info=userinfo,
-                    message_segment=message_segment,
-                    reply=None,
-                    is_head=False,
-                    is_emoji=False,
-                )
-                message_manager.add_message(bot_message)
+        await self.message_process(message_cq)
 
 
 # 创建全局ChatBot实例


### PR DESCRIPTION
# 请填写以下内容
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [ ] 本次更新 **包含破坏性变更**（如数据库结构变更、配置文件修改等）
3. - [x] 本次更新是否经过测试
4. - [x] 请**不要**在数据库中添加group_id字段，这会影响本项目对其他平台的兼容
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
   - 将handle_message函数中的消息实例处理部分提取出来，形成message_process函数（提高代码复用率）
   - 将“戳一戳”的通知处理为一条通用消息实例，交由message_process函数处理（走WillingManager和情绪处理）
   - 小修复：添加了群组过滤，现在不会对非白名单的群组里的戳一戳（无论是不是戳自己的）有回应
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
![b2f321bf7c2c7dc2a663def1d0658c12](https://github.com/user-attachments/assets/2f9f2c72-784f-4288-8992-f903e1bc3495)
- **附加信息**:
