### PR TITLE
docs: 修复 docker 配置文档中的外链地址错误

### DIFF
--- a/docs/docker_deploy.md
+++ b/docs/docker_deploy.md
@@ -41,7 +41,7 @@ NAPCAT_UID=$(id -u) NAPCAT_GID=$(id -g) docker-compose up -d
 
 ### 3. 修改配置并重启Docker
 
-- 请前往 [🎀 新手配置指南](docs/installation_cute.md) 或 [⚙️ 标准配置指南](docs/installation_standard.md) 完成`.env.prod`与`bot_config.toml`配置文件的编写\
+- 请前往 [🎀 新手配置指南](installation_cute.md) 或 [⚙️ 标准配置指南](installation_standard.md) 完成`.env.prod`与`bot_config.toml`配置文件的编写\
 **需要注意`.env.prod`中HOST处IP的填写，Docker中部署和系统中直接安装的配置会有所不同**
 
 - 重启Docker容器:


### PR DESCRIPTION
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [ ] 本次更新 **包含破坏性变更**（如数据库结构变更、配置文件修改等）
3. - [x] 本次更新是否经过测试
4. - [x] 请**不要**在数据库中添加group_id字段，这会影响本项目对其他平台的兼容
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：docker 配置文档中的跳转链接地址错误
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**：我认为在面前 docker 镜像没有实时同步到 docker hub 的情况下，其实可以把 docker compose 的 maimbot 暂时改成部署的时候自动 build 镜像，这样只需要切换分支就可以获得最新的稳定版本，也方便快速迭代
