### PR TITLE
fix: 构建记忆时重复读取同一段消息，导致token消耗暴增

### DIFF
--- a/src/plugins/chat/message.py
+++ b/src/plugins/chat/message.py
@@ -27,6 +27,7 @@ class Message(MessageBase):
     reply: Optional["Message"] = None
     detailed_plain_text: str = ""
     processed_plain_text: str = ""
+    memorized_times: int = 0
 
     def __init__(
         self,

--- a/src/plugins/chat/storage.py
+++ b/src/plugins/chat/storage.py
@@ -19,6 +19,7 @@ class MessageStorage:
                     "processed_plain_text": message.processed_plain_text,
                     "detailed_plain_text": message.detailed_plain_text,
                     "topic": topic,
+                    "memorized_times": message.memorized_times,
                 }
             db.messages.insert_one(message_data)
         except Exception:

--- a/src/plugins/chat/utils.py
+++ b/src/plugins/chat/utils.py
@@ -104,10 +104,13 @@ def get_closest_chat_from_db(length: int, timestamp: str):
         # 转换记录格式
         formatted_records = []
         for record in chat_records:
+            # 兼容行为，前向兼容老数据
             formatted_records.append({
+                '_id': record["_id"],
                 'time': record["time"],
                 'chat_id': record["chat_id"],
-                'detailed_plain_text': record.get("detailed_plain_text", "")  # 添加文本内容
+                'detailed_plain_text': record.get("detailed_plain_text", ""),  # 添加文本内容
+                'memorized_times': record.get("memorized_times", 0)  # 添加记忆次数
             })
             
         return formatted_records


### PR DESCRIPTION
<!-- 提交前必读 -->
- 🔴**当前项目处于重构阶段（2025.3.14-）**
- ✅ 接受：与main直接相关的Bug修复：提交到main-fix分支
- ✅ 接受：部分与重构分支refractor直接相关的Bug修复：提交到refractor分支
- ⚠️ 冻结：所有新功能开发和非紧急重构

# 请填写以下内容
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 本次更新 **包含破坏性变更**（如数据库结构变更、配置文件修改等）
3. - [x] 本次更新是否经过测试
4. - [x] 请**不要**在数据库中添加group_id字段，这会影响本项目对其他平台的兼容
5. 请填写破坏性更新的具体内容（如有）:
  - 数据库中添加了`memorized_times`字段，但已在代码中进行前向兼容处理
7. 请简要说明本次更新的内容和目的：
  - issue#352中提到构建记忆时重复读取同一段消息，导致token消耗暴增的问题，已通过添加`memorized_times`字段限制同一段聊天记录的记忆次数进行修复。可以放心开了
# 其他信息
- **关联  #Issue**：https://github.com/SengokuCola/MaiMBot/issues/352
- **截图/GIF**：
- **附加信息**:
