### PR TITLE
chore: 更新 .gitignore 让其包含由 Webui 生成的 bot config backup 文件, 以及 PyEnv 的配置文件

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ memory_graph.gml
 .env.*
 config/bot_config_dev.toml
 config/bot_config.toml
+config/bot_config.toml.bak
 src/plugins/remote/client_uuid.json
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -205,3 +206,8 @@ jieba.cache
 .idea
 *.iml
 *.ipr
+
+# PyEnv
+#  If using PyEnv and configured to use a specific Python version locally
+#  a .local-version file will be created in the root of the project to specify the version.
+.python-version


### PR DESCRIPTION
这个PR简单修改了一下 .gitignore:
1. 使用 webui 更改配置文件的时候, 会生成 `bot_config.toml.bak` 的备份文件, 这个文件不会被 git 忽略
2. 如果使用 Pyenv, 会在根目录下生成 `.python-version` 这个文件, 这个文件也不在 .gitignore 里
<!-- 提交前必读 -->
- 🔴**当前项目处于重构阶段（2025.3.14-）**
- ✅ 接受：与main直接相关的Bug修复：提交到main-fix分支
- ⚠️ 冻结：所有新功能开发和非紧急重构

# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [ ] 本次更新 **包含破坏性变更**（如数据库结构变更、配置文件修改等）
3. - [x] 本次更新是否经过测试
4. - [x] 请**不要**在数据库中添加group_id字段，这会影响本项目对其他平台的兼容
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

更新了 .gitignore 文件，以忽略机器人配置备份文件和 PyEnv 配置文件。

杂务：
- 更新 .gitignore 以忽略 bot_config.toml.bak 文件。
- 更新 .gitignore 以忽略 .python-version 文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Updates the .gitignore file to ignore bot configuration backup files and PyEnv configuration files.

Chores:
- Update .gitignore to ignore bot_config.toml.bak files.
- Update .gitignore to ignore .python-version files.

</details>