### PR TITLE
🐛 fix(MaiLauncher.bat): 修正 `.env.prod` 复制路径和菜单输入提示

### DIFF
--- a/MaiLauncher.bat
+++ b/MaiLauncher.bat
@@ -331,7 +331,7 @@ if not exist config/bot_config.toml (
 
 )
 if not exist .env.prod (
-    copy /Y "template\.env.prod" ".env.prod"
+    copy /Y "template.env" ".env.prod"
 )
 
 start python webui.py
@@ -362,7 +362,7 @@ if "!choice!"=="5" goto learn_new_knowledge
 if "!choice!"=="6" goto open_knowledge_folder
 if "!choice!"=="7" goto menu
 
-echo 无效的输入，请输入1-6之间的数字
+echo 无效的输入，请输入1-7之间的数字
 timeout /t 2 >nul
 goto tools_menu
 


### PR DESCRIPTION
<!-- 提交前必读 -->
- 🔴**当前项目处于重构阶段（2025.3.14-）**
- ✅ 接受：与main直接相关的Bug修复：提交到main-fix分支
- ⚠️ 冻结：所有新功能开发和非紧急重构

# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [ ] 本次更新 **包含破坏性变更**（如数据库结构变更、配置文件修改等）
3. - [x] 本次更新是否经过测试
4. - [x] 请**不要**在数据库中添加group_id字段，这会影响本项目对其他平台的兼容
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

修复了 `MaiLauncher.bat` 脚本中的一个 bug，该 bug 导致 `.env.prod` 文件从错误的位置被复制。此外，更正了菜单输入提示，以反映正确的选项数量。

Bug 修复：
- 修复了 `.env.prod` 复制路径，以使用正确的模板文件。
- 更正了菜单输入提示，以显示正确的选项数量。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fixes a bug in the MaiLauncher.bat script where the `.env.prod` file was being copied from the wrong location. Also, corrects the menu input prompt to reflect the correct number of options.

Bug Fixes:
- Fixes the `.env.prod` copy path to use the correct template file.
- Corrects the menu input prompt to display the correct number of options.

</details>