### PR TITLE
chore: docker 构建 main-fix 分支

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,11 +4,10 @@ on:
   push:
     branches:
       - main
-      - debug       # 新增 debug 分支触发
-      - stable-dev
+      - main-fix
     tags:
-      - 'v*'       
-  workflow_dispatch: 
+      - 'v*'
+  workflow_dispatch:
 
 jobs:
   build-and-push:
@@ -16,7 +15,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -33,10 +32,8 @@ jobs:
             echo "tags=${{ secrets.DOCKERHUB_USERNAME }}/maimbot:${{ github.ref_name }},${{ secrets.DOCKERHUB_USERNAME }}/maimbot:latest" >> $GITHUB_OUTPUT
           elif [ "${{ github.ref }}" == "refs/heads/main" ]; then
             echo "tags=${{ secrets.DOCKERHUB_USERNAME }}/maimbot:main,${{ secrets.DOCKERHUB_USERNAME }}/maimbot:latest" >> $GITHUB_OUTPUT
-          elif [ "${{ github.ref }}" == "refs/heads/debug" ]; then
-            echo "tags=${{ secrets.DOCKERHUB_USERNAME }}/maimbot:debug" >> $GITHUB_OUTPUT
-          elif [ "${{ github.ref }}" == "refs/heads/stable-dev" ]; then
-            echo "tags=${{ secrets.DOCKERHUB_USERNAME }}/maimbot:stable-dev" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref }}" == "refs/heads/main-fix" ]; then
+            echo "tags=${{ secrets.DOCKERHUB_USERNAME }}/maimbot:main-fix" >> $GITHUB_OUTPUT
           fi
 
       - name: Build and Push Docker Image


### PR DESCRIPTION
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [ ] 本次更新 **包含破坏性变更**（如数据库结构变更、配置文件修改等）
3. - [ ] 本次更新是否经过测试
4. - [x] 请**不要**在数据库中添加group_id字段，这会影响本项目对其他平台的兼容
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：项目分支进行过调整，但docker构建workflow依然是旧分支的配置，希望docker用户也可以尽快用上main-fix分支的修复，故更新workflow

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

CI:
- 更新 Docker 镜像构建工作流，使其在推送到 main-fix 分支时触发。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Update the Docker image build workflow to trigger on pushes to the main-fix branch.

</details>