### PR TITLE
fix(willing):修复cfg变量未被正常引用问题

### DIFF
--- a/src/plugins/willing/mode_classical.py
+++ b/src/plugins/willing/mode_classical.py
@@ -61,7 +61,7 @@ class WillingManager:
                 reply_probability = 0
                 
             if chat_stream.group_info.group_id in config.talk_frequency_down_groups:
-                reply_probability = reply_probability / 3.5
+                reply_probability = reply_probability / config.down_frequency_rate
             
         return reply_probability
     

--- a/src/plugins/willing/mode_custom.py
+++ b/src/plugins/willing/mode_custom.py
@@ -62,7 +62,7 @@ class WillingManager:
                 reply_probability = 0
                 
             if chat_stream.group_info.group_id in config.talk_frequency_down_groups:
-                reply_probability = reply_probability / 3.5
+                reply_probability = reply_probability / config.down_frequency_rate
                 
             if is_mentioned_bot and sender_id == "1026294844":
                 reply_probability = 1


### PR DESCRIPTION
<!-- 提交前必读 -->
- 🔴**当前项目处于重构阶段（2025.3.14-）**
- ✅ 接受：与main直接相关的Bug修复：提交到main-fix分支
- ⚠️ 冻结：所有新功能开发和非紧急重构

# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 本次更新 **包含破坏性变更**（如数据库结构变更、配置文件修改等）
3. - [x] 本次更新是否经过测试
4. - [x] 请**不要**在数据库中添加group_id字段，这会影响本项目对其他平台的兼容
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
# 其他信息
修复cfg变量down_frequency_rate系数未被正常引用问题

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复：
- 修复了由于不正确引用 `down_frequency_rate` 配置变量而导致的回复概率计算错误的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fixes incorrect reply probability calculation due to improper reference of the `down_frequency_rate` configuration variable.

</details>